### PR TITLE
fix(watermarker): add missing `@JsExport` annotations

### DIFF
--- a/watermarker/src/commonMain/kotlin/helper/Compression.kt
+++ b/watermarker/src/commonMain/kotlin/helper/Compression.kt
@@ -8,6 +8,7 @@ package de.fraunhofer.isst.trend.watermarker.helper
 
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
+import kotlin.js.JsExport
 
 const val COMPRESSION_LEVEL: Int = 9
 
@@ -19,6 +20,7 @@ expect object Compression {
     fun inflate(data: List<Byte>): Result<List<Byte>>
 }
 
+@JsExport
 class InflationError(val reason: String) : Event.Error("Compression.inflate") {
     /** Returns a String explaining the event */
     override fun getMessage() = "Error inflating bytes: $reason."

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -22,6 +22,7 @@ import org.kotlincrypto.hash.sha3.SHA3_256
 import kotlin.collections.ArrayList
 import kotlin.js.JsExport
 
+@JsExport
 sealed interface TrendmarkInterface {
     companion object {
         /** Number of bytes used as tag representing the type of the watermark */
@@ -598,6 +599,7 @@ fun Result<List<Watermark>>.toTrendmarks(source: String = "Trendmark"): Result<L
     }
 }
 
+@JsExport
 class RawWatermark(content: List<Byte>) : Trendmark(content) {
     companion object {
         const val SOURCE = "Trendmark.RawWatermark"
@@ -625,6 +627,7 @@ class RawWatermark(content: List<Byte>) : Trendmark(content) {
     override fun getContent() = Result.success(watermarkContent.drop(TAG_SIZE))
 }
 
+@JsExport
 class SizedWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Sized {
     companion object {
         const val SOURCE = "Trendmark.SizedWatermark"
@@ -676,6 +679,7 @@ class SizedWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Sized 
     override fun getSizeRange(): IntRange = SIZE_START_INDEX..SIZE_END_INDEX
 }
 
+@JsExport
 class CRC32Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Checksum {
     companion object {
         const val SOURCE = "Trendmark.CRC32Watermark"
@@ -743,6 +747,7 @@ class CRC32Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Checks
     }
 }
 
+@JsExport
 class SizedCRC32Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Checksum {
     companion object {
@@ -817,6 +822,7 @@ class SizedCRC32Watermark(content: List<Byte>) :
     }
 }
 
+@JsExport
 class SHA3256Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Hash {
     companion object {
         const val SOURCE = "Trendmark.SHA3256Watermark"
@@ -887,6 +893,7 @@ class SHA3256Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Hash
     }
 }
 
+@JsExport
 class SizedSHA3256Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Hash {
     companion object {
@@ -963,6 +970,7 @@ class SizedSHA3256Watermark(content: List<Byte>) :
     }
 }
 
+@JsExport
 class CompressedRawWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Compressed {
     companion object {
         const val SOURCE = "Trendmark.CompressedRawWatermark"
@@ -991,6 +999,7 @@ class CompressedRawWatermark(content: List<Byte>) : Trendmark(content), Trendmar
     }
 }
 
+@JsExport
 class CompressedSizedWatermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Compressed {
     companion object {
@@ -1024,6 +1033,7 @@ class CompressedSizedWatermark(content: List<Byte>) :
         SizedWatermark.SIZE_START_INDEX..SizedWatermark.SIZE_END_INDEX
 }
 
+@JsExport
 class CompressedCRC32Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Checksum {
     companion object {
@@ -1075,6 +1085,7 @@ class CompressedCRC32Watermark(content: List<Byte>) :
     }
 }
 
+@JsExport
 class CompressedSizedCRC32Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Checksum {
     companion object {
@@ -1136,6 +1147,7 @@ class CompressedSizedCRC32Watermark(content: List<Byte>) :
     }
 }
 
+@JsExport
 class CompressedSHA3256Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Hash {
     companion object {
@@ -1190,6 +1202,7 @@ class CompressedSHA3256Watermark(content: List<Byte>) :
     }
 }
 
+@JsExport
 class CompressedSizedSHA3256Watermark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Sized, Trendmark.Hash {
     companion object {

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -84,14 +84,14 @@ sealed interface TrendmarkInterface {
 }
 
 /**
- * Trendmark defines a list of Watermarks with specific format. The format is encoded in the first
- * byte of the watermark, which allows to parse unknown types of Trendmarks. The implemented
- * variants of Trendmark allow to encode addition information like the size or a hash into the
- * watermark. For detailed information about the different formats see
+ * Trendmark defines a list of Watermarks with specific formats. The format is encoded in the first
+ * byte of the watermark, which allows parsing unknown types of Trendmarks. The implemented
+ * variants of Trendmark allow encoding additional information like the size or a hash into the
+ * watermark. For detailed information about the different formats, see
  * [Trendmark.md](https://github.com/FraunhoferISST/TREND/blob/main/docs/Trendmark.md)
  *
  * The constructor expects bytes that represent the given type.
- * To create a new watermark with arbitrary content the companion function `new` of that type must
+ * To create a new watermark with arbitrary content, the companion function `new` of that type must
  * be used.
  *
  * @param content: expects bytes that represent a Trendmark.

--- a/watermarker/src/commonMain/kotlin/watermarks/TrendmarkBuilder.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/TrendmarkBuilder.kt
@@ -6,6 +6,8 @@
  */
 package de.fraunhofer.isst.trend.watermarker.watermarks
 
+import kotlin.js.JsExport
+
 /**
  * The TrendmarkBuilder interface is designed to create classes for generating a Trendmark from
  * various types of data. Implementing classes will provide the specific logic to convert different
@@ -13,6 +15,7 @@ package de.fraunhofer.isst.trend.watermarker.watermarks
  * Trendmark's content. This interface ensures that all types of Trendmarks maintain a consistent
  * structure and can be processed in a standardized way by the watermarking library.
  */
+@JsExport
 interface TrendmarkBuilder {
     /** Generates a Trendmark with the specific content */
     fun finish(): Trendmark


### PR DESCRIPTION
## Description
Adds missing `@JsExport` annotations. 
Minor spelling improvements.
<!-- Describe and give details about the changes. -->

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #76 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
