### PR TITLE
docs: add and update copyright header

### DIFF
--- a/.idea/copyright/Innamark_Fraunhofer_License.xml
+++ b/.idea/copyright/Innamark_Fraunhofer_License.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="keyword" value="Fraunhofer License" />
+    <option name="notice" value="Copyright (c) &amp;#36;originalComment.match(&quot;Copyright \(c\) (\d+)&quot;, 1, &quot;-&quot;, &quot;&amp;#36;today.year&quot;)&amp;#36;today.year Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.&#10;&#10;This work is licensed under the Fraunhofer License (on the basis of the MIT license)&#10;that can be found in the LICENSE file." />
+    <option name="myName" value="Innamark-Fraunhofer-License" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Innamark-Fraunhofer-License" />
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ accepted. See the `CLA.md` file for more information.
 
 ## Git(Hub) Process
 
-Please carefully follow our guidelines for the process with Git and GitHub. Failure to comply 
+Please carefully follow our guidelines for the process with Git and GitHub. Failure to comply
 may result in rejection of the contribution.
 
 ### Issues
@@ -41,7 +41,7 @@ the repository (if you do not have write permission). Create a branch with a des
 ### Pull Requests
 
 Code changes are handled entirely over pull requests. When proposing a change, create a pull
-request from your working branch or fork to the upstream `main` branch, fill out the template, 
+request from your working branch or fork to the upstream `main` branch, fill out the template,
 link it to at least one issue (mandatory) and accept the CLA by keeping the text untouched.
 
 We use the
@@ -68,7 +68,7 @@ that every proposed contribution is related to a previously discussed issue. Pul
 shouldn't be too big to allow a fast integration of changes. We recommend keeping the content
 below 1000 lines of code (LOC).
 
-To keep to whole project up-to-date, please check and adjust the documentation accordingly. See 
+To keep to whole project up-to-date, please check and adjust the documentation accordingly. See
 the [documentation](#documentation) section for more information.
 
 To ensure code quality, every pull request needs at least one approved review from one of the
@@ -78,13 +78,16 @@ Committer team. Further check that all pipelines succeed before a review can be 
 
 Due to the _squash and merge_, the final squashed commit is based on the title of the pull
 request with a link to the pull request. The above example results in:
+
 ```
 feat(watermarker): add watermark compression option (#123)
 ```
-Even if all commits are squashed, we highly recommend using conventional commits to reflect all 
-changes. Tools like [commitlint](https://github.com/conventional-changelog/commitlint) are 
-suggested and can help to stay with the format. Further, we highly recommend to sign every commit 
-with a GPG signature to enable the _Verfied_ flag on [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits).
+
+Even if all commits are squashed, we highly recommend using conventional commits to reflect all
+changes. Tools like [commitlint](https://github.com/conventional-changelog/commitlint) are
+suggested and can help to stay with the format. Further, we highly recommend to sign every commit
+with a GPG signature to enable the _Verfied_ flag
+on [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits).
 
 ### License Header
 
@@ -92,22 +95,26 @@ Every source code file in this project must contain a license header. Example:
 
 ```
 /*
- * Copyright (c) 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2024-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
  */
 ```
 
+When using IntelliJ, the copyright header format is shipped in the `.idea` folder. It is highly
+suggested to update the IntelliJ settings
+to [update the copyright on save](https://www.jetbrains.com/help/idea/copyright.html#update-copyright-on-save).
+
 ## Documentation
 
 Documentation is important for us since it is the starting point for newcomers and a reference for
-experts. We are using the [Docusaurus](https://github.com/facebook/docusaurus/) framework, 
+experts. We are using the [Docusaurus](https://github.com/facebook/docusaurus/) framework,
 located in the `docs` folder.
 
-Please always adjust and update the documentation! Extend the existing markdown files in the 
-`docs/docs` folder or create a new file according to the existing structure. Use numbers in 
-front of the file- and folder-names for sorting. Please use kebab case in the file names for a 
+Please always adjust and update the documentation! Extend the existing markdown files in the
+`docs/docs` folder or create a new file according to the existing structure. Use numbers in
+front of the file- and folder-names for sorting. Please use kebab case in the file names for a
 consistent URL-slug.
 
 In case you add a new file (like an image), remember to declare its license according to
@@ -144,9 +151,9 @@ with minor adjustments:
 - Hard wrap at: 100
 - KDoc max comment line length: 100
 
-Remember that every method must contain a comment since it is used in the automatic 
+Remember that every method must contain a comment since it is used in the automatic
 documentation generation process. Therefore, get familiar with the
-[KDoc syntax](https://kotlinlang.org/docs/kotlin-doc.html#kdoc-syntax) (similar to Javadoc) and 
+[KDoc syntax](https://kotlinlang.org/docs/kotlin-doc.html#kdoc-syntax) (similar to Javadoc) and
 use it for code comments in classes and functions.
 
 ### Autoformatter
@@ -180,7 +187,8 @@ The code style should be shipped in the `.idea` folder. Otherwise, configure it 
             - Whole file
                 - Why not "Changed lines": The whole project should be formatted in this way. This
                   ensures that.
-        - Optimize imports
-            - Removes unused imports
-            - Ensures styleguides on imports
+        - Check "Optimize imports"
+            - All file types
+        - Check "Update coypright notice"
+            - Click "Configure..." and select the shipped copyright notice file
     - [Source](https://www.jetbrains.com/help/idea/reformat-and-rearrange-code.html#reformat-on-save)


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
This PR adds a copyright header template for IntelliJ IDEs and updates the existing copyright headers.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #268

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
